### PR TITLE
Fix Z2JH version

### DIFF
--- a/codehub/cli/helm/install.py
+++ b/codehub/cli/helm/install.py
@@ -18,21 +18,15 @@ def upgrade_helm_chart(cluster_name, region, helm_deploy_dir, hub_deploy_dir):
 def __upgrade_or_install_helm_chart(
     cluster_name, region, helm_deploy_dir, hub_deploy_dir, upgrade=False
 ):
-    install_template_fp = os.path.join(STRUCTURE["templates"]["helm"], "install.yaml")
-    install_deploy_fp = os.path.join(helm_deploy_dir, "install.yaml")
+    chart_template_fp = os.path.join(STRUCTURE["templates"]["helm"], "chart.yaml")
+    chart_deploy_fp = os.path.join(helm_deploy_dir, "chart.yaml")
 
     placeholder_replacements = dict(REGION=region)
-    fill_file_placeholders(
-        install_template_fp, install_deploy_fp, placeholder_replacements
-    )
+    fill_file_placeholders(chart_template_fp, chart_deploy_fp, placeholder_replacements)
 
-    helm = read_yaml(install_deploy_fp)
-
-    chart_release = helm["release"]
-    cluster_namespace = helm["namespace"]
-    region = helm["region"]
-
-    helm_chart = os.path.join(helm_deploy_dir, "helm-chart")
+    helm_config = read_yaml(chart_deploy_fp)
+    repo_config = helm_config["repo"]
+    install_config = helm_config["install"]
 
     config_file = os.path.join(hub_deploy_dir, "config.yaml")
 
@@ -43,40 +37,34 @@ def __upgrade_or_install_helm_chart(
             "container",
             "clusters",
             "get-credentials",
-            f"--location={region}",
+            f"--location={install_config['region']}",
             cluster_name,
         ]
     )
 
-    if upgrade:
-        cmds.append(
-            [
-                "helm",
-                "upgrade",
-                "--cleanup-on-fail",
-                chart_release,
-                helm_chart,
-                "--namespace",
-                cluster_namespace,
-                "--values",
-                config_file,
-            ]
-        )
-    else:
-        cmds.append(
-            [
-                "helm",
-                "upgrade",
-                "--cleanup-on-fail",
-                "--install",
-                chart_release,
-                helm_chart,
-                "--namespace",
-                cluster_namespace,
-                "--values",
-                config_file,
-            ]
-        )
+    # Add and update Helm repo
+    cmds.append(["helm", "repo", "add", repo_config["repo_name"], repo_config["url"]])
+    cmds.append(["helm", "repo", "update"])
+
+    # Main helm command
+    helm_command = [
+        "helm",
+        "upgrade",
+        "--cleanup-on-fail",
+    ]
+    if not upgrade:
+        helm_command.append("--install")
+    helm_command += [
+        install_config["release"],
+        f"{repo_config['repo_name']}/{install_config['chart_name']}",
+        "--namespace",
+        install_config["namespace"],
+        "--version",
+        install_config["chart_version"],
+        "--values",
+        config_file,
+    ]
+    cmds.append(helm_command)
 
     for cmd in cmds:
         run_cmd(cmd)

--- a/codehub/templates/helm/chart.yaml
+++ b/codehub/templates/helm/chart.yaml
@@ -1,0 +1,9 @@
+repo:
+  url: https://hub.jupyter.org/helm-chart/
+  repo_name: jupyterhub
+install:
+  release: jhub
+  namespace: jhub
+  region: {{REGION}}
+  chart_name: jupyterhub
+  chart_version: 4.2.0

--- a/codehub/templates/helm/install.yaml
+++ b/codehub/templates/helm/install.yaml
@@ -1,3 +1,0 @@
-release: jhub
-namespace: jhub
-region: {{REGION}}

--- a/codehub/templates/helm/repo.yaml
+++ b/codehub/templates/helm/repo.yaml
@@ -1,2 +1,0 @@
-url: https://github.com/jupyterhub/zero-to-jupyterhub-k8s
-hash: fcf9c2e92a450e175a9d53abbe6dbbb2936df09


### PR DESCRIPTION
The Zero to Jupyterhub version was old enough that the Kubernetes API has had breaking changes since the chart was released. Fixed by using the latest version instead.

Since we no longer rely on a very specific, untagged version of the chart, the code is refactored to instead use a remote helm chart repo with a specified version. 