### PR TITLE
Fix registry password template

### DIFF
--- a/codehub/cli/helm/create.py
+++ b/codehub/cli/helm/create.py
@@ -42,7 +42,10 @@ def create_deploy(
     placeholder_replacements["SUDOERS"] = " ".join(admins)
 
     placeholder_replacements["REGISTRY_HOSTNAME"] = cloud_state.docker_registry_hostname
-    placeholder_replacements["REGISTRY_PASSWORD"] = cloud_state.hub_sa_key
+    # The spaces after newline are important for the indentation in the yaml file
+    placeholder_replacements["REGISTRY_PASSWORD"] = cloud_state.hub_sa_key.replace(
+        "\n", "\n    "
+    )
     placeholder_replacements["DOCKER_IMAGE"] = cloud_state.docker_image
 
     if "DOCKER_IMAGE_TAG" not in placeholder_replacements:

--- a/codehub/templates/hub/imagePullSecrets.yaml
+++ b/codehub/templates/hub/imagePullSecrets.yaml
@@ -8,7 +8,8 @@ imagePullSecret:
   registry: {{REGISTRY_HOSTNAME}}
   username: {{REGISTRY_USERNAME}}
   email: {{REGISTRY_EMAIL}}
-  password: {{REGISTRY_PASSWORD}}
+  password: |-
+    {{REGISTRY_PASSWORD}}
 
 # imagePullSecrets is configuration to reference the k8s Secret resources the
 # Helm chart's pods can get credentials from to pull their images.


### PR DESCRIPTION
The GCP Docker Registry password is a json string with newlines, which breaks the yaml formatting of the chart config when the template variable is replaced.
Fixed by making the password a multiline yaml string, and fixing the indentation before filling the template.

The alternative would be to refactor and use a proper templating engine, but that is out of scope for this fix.