### PR TITLE
Authenticate to GKE before upgrading helm chart

### DIFF
--- a/codehub/cli/create.py
+++ b/codehub/cli/create.py
@@ -74,9 +74,11 @@ def upgrade(config: UpgradeConfig):
         deploy_config,
         config.hub_config,
     )
-    install_helm_chart(deploy_config, upgrade=True)
 
     authenticate_k8s_GKE(config.name)
+
+    install_helm_chart(deploy_config, upgrade=True)
+
     wait_for_hub_to_get_ready(k8s_dir)
 
 


### PR DESCRIPTION
The authentication to GKE was done after attempting to upgrade the helm chart. This would be problematic if another kubernetes context was currently in use. Fixed by authenticating before helm upgrade.