### PR TITLE
General deduplication of function arguments

### DIFF
--- a/codehub/cli/config.py
+++ b/codehub/cli/config.py
@@ -44,3 +44,9 @@ class CreateConfig:
     region: str
     zone: str
     machine_type: str
+
+
+@dataclass
+class OAuthConfig:
+    client_id: str
+    client_secret: str

--- a/codehub/cli/config.py
+++ b/codehub/cli/config.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 import os
 from pathlib import Path
 
+from codehub.cli.gcp.terraform import TerraformOutput
+
 
 ROOT = Path(__file__).parents[2]
 PACKAGE_ROOT = Path(__file__).parents[1]
@@ -50,3 +52,13 @@ class CreateConfig:
 class OAuthConfig:
     client_id: str
     client_secret: str
+
+
+@dataclass
+class DeployConfig:
+    name: str
+    region: str
+    helm_dir: str
+    hub_dir: str
+    k8s_dir: str
+    cloud_state: TerraformOutput

--- a/codehub/cli/config.py
+++ b/codehub/cli/config.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import os
 from pathlib import Path
 
@@ -34,3 +35,12 @@ SLEEP_TIME = 5
 SLEEP_THRESHOLD = 600
 TIMEOUT_ERROR = "Timeout expired."
 CLUSTER_MAX_LEN = 14
+
+
+@dataclass
+class CreateConfig:
+    name: str
+    admins: list[str]
+    region: str
+    zone: str
+    machine_type: str

--- a/codehub/cli/config.py
+++ b/codehub/cli/config.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 import os
 from pathlib import Path
-
-from codehub.cli.gcp.terraform import TerraformOutput
+from typing import Optional
 
 
 ROOT = Path(__file__).parents[2]
@@ -40,12 +39,16 @@ CLUSTER_MAX_LEN = 14
 
 
 @dataclass
-class CreateConfig:
-    name: str
-    admins: list[str]
-    region: str
-    zone: str
-    machine_type: str
+class CloudState:
+    nfs_ip: str
+    nfs_name: str
+    cluster_id: str
+    hub_sa_key: str
+    cluster_endpoint: str
+    cluster_cert: str
+    gcp_token: str
+    docker_registry_hostname: str
+    docker_image: str
 
 
 @dataclass
@@ -55,10 +58,33 @@ class OAuthConfig:
 
 
 @dataclass
+class HubConfig:
+    admins: list[str]
+    https: Optional[str] = None
+    oauth_config: Optional[OAuthConfig] = None
+    contact_email: Optional[str] = None
+
+
+@dataclass
+class CreateConfig:
+    name: str
+    admins: list[str]
+    region: str
+    zone: str
+    machine_type: str
+
+
+@dataclass
+class UpgradeConfig:
+    name: str
+    hub_config: HubConfig
+
+
+@dataclass
 class DeployConfig:
     name: str
     region: str
     helm_dir: str
     hub_dir: str
     k8s_dir: str
-    cloud_state: TerraformOutput
+    cloud_state: CloudState

--- a/codehub/cli/create.py
+++ b/codehub/cli/create.py
@@ -4,13 +4,12 @@ import logging
 import json
 from typing import Optional
 from codehub.cli.gcp.terraform import (
-    TerraformOutput,
     setup_terraform,
     terraform_apply,
     terraform_output,
 )
 from distutils.dir_util import copy_tree
-from codehub.cli.config import STRUCTURE, CreateConfig, OAuthConfig
+from codehub.cli.config import STRUCTURE, CreateConfig, DeployConfig, OAuthConfig
 from codehub.cli.gcp.helpers import authenticate_k8s_GKE
 from codehub.cli.k8s.create import create_k8s_resources
 from codehub.cli.helm.create import create_deploy
@@ -21,7 +20,7 @@ import kubernetes.client.rest  # Add this import for the exception handling
 
 
 def create_infrastructure(config: CreateConfig):
-    _, _, k8s_dir, cloud_dir = __create_deploy_structure(config.name)
+    helm_dir, hub_dir, k8s_dir, cloud_dir = __create_deploy_structure(config.name)
 
     setup_terraform(
         config=config,
@@ -29,12 +28,10 @@ def create_infrastructure(config: CreateConfig):
     )
 
     cloud_state = terraform_apply(cloud_dir=cloud_dir)
-    __create_k8s_resources(
-        config.name,
-        deploy_dir=k8s_dir,
-        nfs_name=cloud_state.nfs_name,
-        nfs_ip=cloud_state.nfs_ip,
+    deploy_config = DeployConfig(
+        config.name, config.region, helm_dir, hub_dir, k8s_dir, cloud_state
     )
+    __create_k8s_resources(deploy_config)
 
     return get_ip(config.name, k8s_dir)
 
@@ -48,19 +45,14 @@ def create(config: CreateConfig):
     )
 
     cloud_state = terraform_apply(cloud_dir=cloud_dir)
-    __create_k8s_resources(
-        config.name,
-        deploy_dir=k8s_dir,
-        nfs_name=cloud_state.nfs_name,
-        nfs_ip=cloud_state.nfs_ip,
+    deploy_config = DeployConfig(
+        config.name, config.region, helm_dir, hub_dir, k8s_dir, cloud_state
     )
 
+    __create_k8s_resources(deploy_config)
+
     __install_helm_chart(
-        config.name,
-        region=config.region,
-        helm_deploy_dir=helm_dir,
-        hub_deploy_dir=hub_dir,
-        cloud_state=cloud_state,
+        deploy_config,
         admins=config.admins,
     )
 
@@ -77,16 +69,13 @@ def upgrade(name, admins, https=None, oauth_config: Optional[OAuthConfig] = None
     )
     cloud_state = terraform_output(cloud_dir=cloud_dir)
 
-    last_helm_install = read_yaml(os.path.join(old_deploy_dir, "helm", "chart.yaml"))[
-        "install"
+    region = read_yaml(os.path.join(old_deploy_dir, "helm", "chart.yaml"))["install"][
+        "region"
     ]
+    deploy_config = DeployConfig(name, region, helm_dir, hub_dir, k8s_dir, cloud_state)
 
     __upgrade_helm_chart(
-        name,
-        region=last_helm_install["region"],
-        helm_deploy_dir=helm_dir,
-        hub_deploy_dir=hub_dir,
-        cloud_state=cloud_state,
+        deploy_config,
         admins=admins,
         https=https,
         oauth_config=oauth_config,
@@ -130,10 +119,10 @@ def __upgrade_deploy_structure(name, old_deploy_dir):
     return helm_dir, hub_dir, k8s_dir, cloud_dir
 
 
-def __create_k8s_resources(name, deploy_dir, nfs_name, nfs_ip):
-    authenticate_k8s_GKE(name)
+def __create_k8s_resources(deploy_config: DeployConfig):
+    authenticate_k8s_GKE(deploy_config.name)
     try:
-        create_k8s_resources(deploy_dir, nfs_name, nfs_ip)
+        create_k8s_resources(deploy_config)
     except kubernetes.client.rest.ApiException as e:
         logger = logging.getLogger(__name__)
         # If the error is due to a resource already existing, we can continue
@@ -145,52 +134,31 @@ def __create_k8s_resources(name, deploy_dir, nfs_name, nfs_ip):
 
 
 def __install_helm_chart(
-    name,
-    region,
-    helm_deploy_dir,
-    hub_deploy_dir,
-    cloud_state: TerraformOutput,
+    deploy_config: DeployConfig,
     admins,
 ):
-    __create_deploy(name, helm_deploy_dir, hub_deploy_dir, cloud_state, admins)
-    install_helm_chart(
-        name,
-        region=region,
-        helm_deploy_dir=helm_deploy_dir,
-        hub_deploy_dir=hub_deploy_dir,
-    )
+    __create_deploy(deploy_config, admins)
+    install_helm_chart(deploy_config)
 
 
 def __upgrade_helm_chart(
-    name,
-    region,
-    helm_deploy_dir,
-    hub_deploy_dir,
-    cloud_state: TerraformOutput,
+    deploy_config: DeployConfig,
     admins,
     https=None,
     oauth_config: Optional[OAuthConfig] = None,
 ):
     __create_deploy(
-        name,
-        helm_deploy_dir,
-        hub_deploy_dir,
-        cloud_state=cloud_state,
+        deploy_config,
         admins=admins,
         https=https,
         oauth_config=oauth_config,
     )
 
-    upgrade_helm_chart(
-        name, region, helm_deploy_dir=helm_deploy_dir, hub_deploy_dir=hub_deploy_dir
-    )
+    upgrade_helm_chart(deploy_config)
 
 
 def __create_deploy(
-    name,
-    helm_deploy_dir,
-    hub_deploy_dir,
-    cloud_state: TerraformOutput,
+    deploy_config: DeployConfig,
     admins,
     https=None,
     oauth_config: Optional[OAuthConfig] = None,
@@ -200,12 +168,9 @@ def __create_deploy(
         contact_email = json.loads(f.read())["client_email"]
 
     create_deploy(
-        name,
+        deploy_config,
         contact_email=contact_email,
         admins=admins,
-        helm_deploy_dir=helm_deploy_dir,
-        hub_deploy_dir=hub_deploy_dir,
-        cloud_state=cloud_state,
         https=https,
         oauth_config=oauth_config,
     )

--- a/codehub/cli/create.py
+++ b/codehub/cli/create.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import logging
 import json
+from typing import Optional
 from codehub.cli.gcp.terraform import (
     TerraformOutput,
     setup_terraform,
@@ -9,7 +10,7 @@ from codehub.cli.gcp.terraform import (
     terraform_output,
 )
 from distutils.dir_util import copy_tree
-from codehub.cli.config import STRUCTURE, CreateConfig
+from codehub.cli.config import STRUCTURE, CreateConfig, OAuthConfig
 from codehub.cli.gcp.helpers import authenticate_k8s_GKE
 from codehub.cli.k8s.create import create_k8s_resources
 from codehub.cli.helm.create import create_deploy
@@ -68,7 +69,7 @@ def create(config: CreateConfig):
     return get_ip(config.name, k8s_dir)
 
 
-def upgrade(name, admins, https=None, client_id=None, client_secret=None):
+def upgrade(name, admins, https=None, oauth_config: Optional[OAuthConfig] = None):
     old_deploy_dir = get_latest_deployment(name=name)
 
     helm_dir, hub_dir, k8s_dir, cloud_dir = __upgrade_deploy_structure(
@@ -88,8 +89,7 @@ def upgrade(name, admins, https=None, client_id=None, client_secret=None):
         cloud_state=cloud_state,
         admins=admins,
         https=https,
-        client_id=client_id,
-        client_secret=client_secret,
+        oauth_config=oauth_config,
     )
 
     authenticate_k8s_GKE(name)
@@ -169,8 +169,7 @@ def __upgrade_helm_chart(
     cloud_state: TerraformOutput,
     admins,
     https=None,
-    client_id=None,
-    client_secret=None,
+    oauth_config: Optional[OAuthConfig] = None,
 ):
     __create_deploy(
         name,
@@ -179,8 +178,7 @@ def __upgrade_helm_chart(
         cloud_state=cloud_state,
         admins=admins,
         https=https,
-        client_id=client_id,
-        client_secret=client_secret,
+        oauth_config=oauth_config,
     )
 
     upgrade_helm_chart(
@@ -195,8 +193,7 @@ def __create_deploy(
     cloud_state: TerraformOutput,
     admins,
     https=None,
-    client_id=None,
-    client_secret=None,
+    oauth_config: Optional[OAuthConfig] = None,
 ):
     contact_email = None
     with open(STRUCTURE["secrets"]["gcp"]["sa"], "rt") as f:
@@ -210,6 +207,5 @@ def __create_deploy(
         hub_deploy_dir=hub_deploy_dir,
         cloud_state=cloud_state,
         https=https,
-        client_id=client_id,
-        client_secret=client_secret,
+        oauth_config=oauth_config,
     )

--- a/codehub/cli/entrypoint.py
+++ b/codehub/cli/entrypoint.py
@@ -1,6 +1,7 @@
 import click
 import logging
 import sys
+from codehub.cli.config import CreateConfig
 from codehub.cli.create import create, upgrade, scale, create_infrastructure
 from codehub.cli.delete import delete
 from codehub.cli.helpers import check_commands, validate_cluster_name, check_credentials
@@ -37,15 +38,10 @@ def createcluster(name, admin, region, zone, machine_type):
     logger = logging.getLogger(__name__)
     logger.info(f"Creating cluster '{name}'")
 
-    admins = [i.lower() for i in admin]
+    admins = [user.lower() for user in admin]
+    config = CreateConfig(name, admins, region, zone, machine_type)
 
-    res = create(
-        name=name,
-        admins=admins,
-        region=region,
-        zone=zone,
-        machine_type=machine_type,
-    )
+    res = create(config)
 
     logger.debug(f"{create.__module__}.{create.__name__} output:")
     logger.debug(res)
@@ -153,12 +149,10 @@ def createclusterinfra(name, region, zone, machine_type):
     logger = logging.getLogger(__name__)
     logger.info(f"Creating cluster '{name}'")
 
-    res = create_infrastructure(
-        name=name,
-        region=region,
-        zone=zone,
-        machine_type=machine_type,
-    )
+    admins = []
+    config = CreateConfig(name, admins, region, zone, machine_type)
+
+    res = create_infrastructure(config)
 
     logger.debug(f"{create.__module__}.{create.__name__} output:")
     logger.debug(res)

--- a/codehub/cli/entrypoint.py
+++ b/codehub/cli/entrypoint.py
@@ -42,7 +42,8 @@ def createcluster(name, admin, region, zone, machine_type):
     admins = [user.lower() for user in admin]
     config = CreateConfig(name, admins, region, zone, machine_type)
 
-    res = create(config)
+    deploy_config = create(config)
+    res = get_ip(name, deploy_config.k8s_dir)
 
     logger.debug(f"{create.__module__}.{create.__name__} output:")
     logger.debug(res)
@@ -152,7 +153,8 @@ def createclusterinfra(name, region, zone, machine_type):
     admins = []
     config = CreateConfig(name, admins, region, zone, machine_type)
 
-    res = create_infrastructure(config)
+    deploy_config = create_infrastructure(config)
+    res = get_ip(name, deploy_config.k8s_dir)
 
     logger.debug(f"{create.__module__}.{create.__name__} output:")
     logger.debug(res)

--- a/codehub/cli/entrypoint.py
+++ b/codehub/cli/entrypoint.py
@@ -1,7 +1,8 @@
+from typing import Optional
 import click
 import logging
 import sys
-from codehub.cli.config import CreateConfig
+from codehub.cli.config import CreateConfig, OAuthConfig
 from codehub.cli.create import create, upgrade, scale, create_infrastructure
 from codehub.cli.delete import delete
 from codehub.cli.helpers import check_commands, validate_cluster_name, check_credentials
@@ -60,32 +61,32 @@ def upgradecluster(name, admin, https=None, client_id=None, client_secret=None):
     logger = logging.getLogger(__name__)
     logger.info(f"Updating cluster '{name}'")
 
-    https_passed = https is not None
-    client_id_passed = client_id is not None
-    client_secret_passed = client_secret is not None
-    passed_correct_args = https_passed and (client_id_passed is client_secret_passed)
-    passed_no_args = not https_passed and not (client_id_passed or client_secret_passed)
+    oauth_config: Optional[OAuthConfig] = None
+    if https is not None:
+        if client_id and client_secret:
+            oauth_config = OAuthConfig(client_id=client_id, client_secret=client_secret)
+        # None or both need to be passed
+        elif client_id or client_secret:
+            raise ValueError(
+                "To add oauth you need to pass the following arguments\n"
+                + "`--https` <host-name>\n"
+                + "`--client-id` <github-client-id>\n"
+                + "`--client-secret` <github-client-secret>"
+            )
 
     admins = [i.lower() for i in admin]
 
-    if passed_correct_args or passed_no_args:
-        res = upgrade(
-            name=name,
-            admins=admins,
-            https=https,
-            client_id=client_id,
-            client_secret=client_secret,
-        )
+    res = upgrade(
+        name=name,
+        admins=admins,
+        https=https,
+        oauth_config=oauth_config,
+    )
 
-        logger.debug(f"{upgrade.__module__}.{upgrade.__name__} output:")
-        logger.debug(res)
+    logger.debug(f"{upgrade.__module__}.{upgrade.__name__} output:")
+    logger.debug(res)
 
-        logger.info(f"Cluster '{name}' upgraded successfully")
-    else:
-        logger.warning("To add oauth you need to pass the following arguments")
-        logger.warning("`--https` <host-name>")
-        logger.warning("`--client-id` <github-client-id>")
-        logger.warning("`--client-secret` <github-client-secret>")
+    logger.info(f"Cluster '{name}' upgraded successfully")
 
 
 @cli.command()

--- a/codehub/cli/gcp/terraform.py
+++ b/codehub/cli/gcp/terraform.py
@@ -3,7 +3,7 @@ import json
 import os
 from typing import Any, List, Optional
 from distutils.dir_util import copy_tree
-from codehub.cli.config import STRUCTURE
+from codehub.cli.config import STRUCTURE, CreateConfig
 from codehub.cli.helpers import (
     fill_file_placeholders,
     run_cmd,
@@ -26,10 +26,7 @@ class TerraformOutput:
 
 def setup_terraform(
     *,
-    cluster_name: str,
-    region: str,
-    zone: str,
-    machine_type: str,
+    config: CreateConfig,
     cloud_dir: str,
 ) -> None:
     copy_tree(STRUCTURE["templates"]["cloud"], cloud_dir)
@@ -38,10 +35,10 @@ def setup_terraform(
     gcp_project = _get_project_from_sa(gcp_sa_path)
 
     placeholder_replacements = dict(
-        CLUSTER_NAME=cluster_name,
-        REGION=region,
-        ZONE=zone,
-        MACHINE_TYPE=machine_type,
+        CLUSTER_NAME=config.name,
+        REGION=config.region,
+        ZONE=config.zone,
+        MACHINE_TYPE=config.machine_type,
         GCP_SA_PATH=gcp_sa_path,
         GCP_PROJECT_NAME=gcp_project,
     )

--- a/codehub/cli/gcp/terraform.py
+++ b/codehub/cli/gcp/terraform.py
@@ -3,25 +3,12 @@ import json
 import os
 from typing import Any, List, Optional
 from distutils.dir_util import copy_tree
-from codehub.cli.config import STRUCTURE, CreateConfig
+from codehub.cli.config import STRUCTURE, CreateConfig, CloudState
 from codehub.cli.helpers import (
     fill_file_placeholders,
     run_cmd,
     run_cmd_passthrough_stdout,
 )
-
-
-@dataclasses.dataclass
-class TerraformOutput:
-    nfs_ip: str
-    nfs_name: str
-    cluster_id: str
-    hub_sa_key: str
-    cluster_endpoint: str
-    cluster_cert: str
-    gcp_token: str
-    docker_registry_hostname: str
-    docker_image: str
 
 
 def setup_terraform(
@@ -55,7 +42,7 @@ def terraform_apply(
     *,
     cloud_dir: str,
     additional_vars: Optional[dict[str, Any]] = None,
-) -> TerraformOutput:
+) -> CloudState:
     terraform_cmd = _terraform_cmd(cloud_dir)
     run_cmd(terraform_cmd + ["init"])
 
@@ -84,13 +71,13 @@ def terraform_destroy(*, cloud_dir: str):
     )
 
 
-def terraform_output(*, cloud_dir: str) -> TerraformOutput:
+def terraform_output(*, cloud_dir: str) -> CloudState:
     command = _terraform_cmd(cloud_dir) + ["output", "-json"]
     terraform_output: dict[str, dict[str, Any]] = json.loads(
         run_cmd(command, verbose=False)
     )
     output = {key: val_dict["value"] for key, val_dict in terraform_output.items()}
-    return TerraformOutput(**output)
+    return CloudState(**output)
 
 
 def _get_project_from_sa(gcp_sa_path: str) -> str:

--- a/codehub/cli/helm/install.py
+++ b/codehub/cli/helm/install.py
@@ -1,34 +1,28 @@
 import os
 from codehub.cli.helpers import run_cmd, read_yaml, fill_file_placeholders
-from codehub.cli.config import STRUCTURE
+from codehub.cli.config import STRUCTURE, DeployConfig
 
 
-def install_helm_chart(cluster_name, region, helm_deploy_dir, hub_deploy_dir):
-    __upgrade_or_install_helm_chart(
-        cluster_name, region, helm_deploy_dir, hub_deploy_dir, upgrade=False
-    )
+def install_helm_chart(deploy_config: DeployConfig):
+    __upgrade_or_install_helm_chart(deploy_config, upgrade=False)
 
 
-def upgrade_helm_chart(cluster_name, region, helm_deploy_dir, hub_deploy_dir):
-    __upgrade_or_install_helm_chart(
-        cluster_name, region, helm_deploy_dir, hub_deploy_dir, upgrade=True
-    )
+def upgrade_helm_chart(deploy_config: DeployConfig):
+    __upgrade_or_install_helm_chart(deploy_config, upgrade=True)
 
 
-def __upgrade_or_install_helm_chart(
-    cluster_name, region, helm_deploy_dir, hub_deploy_dir, upgrade=False
-):
+def __upgrade_or_install_helm_chart(deploy_config: DeployConfig, upgrade=False):
     chart_template_fp = os.path.join(STRUCTURE["templates"]["helm"], "chart.yaml")
-    chart_deploy_fp = os.path.join(helm_deploy_dir, "chart.yaml")
+    chart_deploy_fp = os.path.join(deploy_config.helm_dir, "chart.yaml")
 
-    placeholder_replacements = dict(REGION=region)
+    placeholder_replacements = dict(REGION=deploy_config.region)
     fill_file_placeholders(chart_template_fp, chart_deploy_fp, placeholder_replacements)
 
     helm_config = read_yaml(chart_deploy_fp)
     repo_config = helm_config["repo"]
     install_config = helm_config["install"]
 
-    config_file = os.path.join(hub_deploy_dir, "config.yaml")
+    config_file = os.path.join(deploy_config.hub_dir, "config.yaml")
 
     cmds = []
     cmds.append(
@@ -38,7 +32,7 @@ def __upgrade_or_install_helm_chart(
             "clusters",
             "get-credentials",
             f"--location={install_config['region']}",
-            cluster_name,
+            deploy_config.name,
         ]
     )
 

--- a/codehub/cli/helm/install.py
+++ b/codehub/cli/helm/install.py
@@ -3,15 +3,7 @@ from codehub.cli.helpers import run_cmd, read_yaml, fill_file_placeholders
 from codehub.cli.config import STRUCTURE, DeployConfig
 
 
-def install_helm_chart(deploy_config: DeployConfig):
-    __upgrade_or_install_helm_chart(deploy_config, upgrade=False)
-
-
-def upgrade_helm_chart(deploy_config: DeployConfig):
-    __upgrade_or_install_helm_chart(deploy_config, upgrade=True)
-
-
-def __upgrade_or_install_helm_chart(deploy_config: DeployConfig, upgrade=False):
+def install_helm_chart(deploy_config: DeployConfig, *, upgrade: bool):
     chart_template_fp = os.path.join(STRUCTURE["templates"]["helm"], "chart.yaml")
     chart_deploy_fp = os.path.join(deploy_config.helm_dir, "chart.yaml")
 


### PR DESCRIPTION
A large number of the functions are thin wrappers around other functions, so when they have a large number of arguments, very little logic is spread over many lines. 

To make the codebase more readable, most arguments have been condensed into a couple of configuration objects that are passed instead. The result is a large reduction in the number of lines, without making the code more complex. Several functions were also removed altogether since it became clear that they were too thin wrappers to justify.